### PR TITLE
Add AWS deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,15 @@ services:
 
 after_deploy:
   - echo "done deploying"
+
+deploy:
+  provider: elasticbeanstalk
+  access_key_id: $ACCESSKEYID
+  secret_access_key:
+    secure: "$SECRETACCESSKEY"
+  region: "us-east-1"
+  app: "avojak.com"
+  env: "avojak-prod"
+  bucket_name: "avojak.com"
+  on:
+    branch: master


### PR DESCRIPTION
Add deployment to S3, which will be used to store the Docker image for Elastic Beanstalk to use.