### PR TITLE
Fix project page header spacing

### DIFF
--- a/public/assets/css/custom.css
+++ b/public/assets/css/custom.css
@@ -44,7 +44,6 @@ header {
 
 main {
   text-align: center;
-  margin-top: 10%;
 }
 
 section {
@@ -152,6 +151,11 @@ div.bio {
    Project Pages
    ========================================================================== */
 
+div.project-header {
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+
 div.github-badges {
   margin-top: 20px;
   margin-bottom: 20px;
@@ -236,6 +240,10 @@ a.social-icon:hover {
 
 @media (min-width: 768px) {
 
+  main {
+    margin-top: 125px;
+  }
+
   #gravatar-small {
     display: none;
   }
@@ -243,6 +251,10 @@ a.social-icon:hover {
 }
 
 @media (max-width: 767px) {
+
+  main {
+    margin-top: 70px;
+  }
 
   .social-wrapper span {
     padding-left: 10px;

--- a/views/pages/project.ejs
+++ b/views/pages/project.ejs
@@ -11,7 +11,7 @@
     <main>
 
     	<div class="container">
-        <div class="row">
+        <div class="project-header row">
           <h1><%= project.name %></h1> <span class="label label-default"><%= project.status %></span>
           <!-- <span class="label label-default">Eclipse Plugin</span> -->
         </div>


### PR DESCRIPTION
Fixes the small margin on the project page headers. Also fixes the inconsistent margin size due to using % margins instead of px.

Addresses https://github.com/avojak/avojak/issues/12